### PR TITLE
アイコン選択後の詳細入力画面を作成した

### DIFF
--- a/src/components/mix/mix-modal-screen.vue
+++ b/src/components/mix/mix-modal-screen.vue
@@ -1,51 +1,111 @@
 <template>
-    <modal-screen :isShow="getModalState">
-      <div class="iconList">
+  <modal-screen :isShow="getModalState">
+    <div class="wrap">
+      <!-- アイコン選択画面 -->
+      <div :class="`iconList${isSelected ? ' is-hide' : ''}`">
         <p class="iconList__title">アイコンを選択してください</p>
         <ul class="iconList__items">
           <li v-for="(icon, index) of icons" :key="index" class="iconList__item">
             <circle-icon
               :color="icon.hexCode"
-              :img="icon.svg"
-              :size="48" @click.native="clickHandler(icon.hexCode, icon.svg)"/>
+              :img="icon.svgName"
+              :size="48"
+              @click.native="selectIcon(icon.hexCode, icon.svgName)"
+            />
           </li>
         </ul>
       </div>
-    </modal-screen>
+
+      <!-- 予定入力画面 -->
+      <div :class="`setTodo${isSelected ? '' : ' is-hide'}`">
+        <div class="setTodo__back" @click="backToIconSelect()">アイコン選択に戻る</div>
+        <ul class="setTodo__settingList">
+          <li class="setTodo__settingItem">
+            <p class="setTodo__text">選択済みのアイコン</p>
+            <circle-icon
+              :color="todo.icon.hexCode"
+              :img="todo.icon.svgName"
+              :size="48"/>
+          </li>
+          <li class="setTodo__settingItem">
+            <p class="setTodo__text">予定時刻</p>
+            <todo-time
+              @emitHour="getHour"
+              @emitMin="getMin"
+              :hour="todo.time.hour"
+              :min="todo.time.min"/>
+          </li>
+          <li class="setTodo__settingItem">
+            <p class="setTodo__text">予定の詳細</p>
+            <todo-textarea @emitValue="getText"/>
+          </li>
+          <app-button
+            :isActived="true"
+            @click.native="setDataInTodoItem(todo)"
+          >決定</app-button>
+        </ul>
+      </div>
+    </div>
+  </modal-screen>
 </template>
 
 <script>
-import ModalScreen from '~/components/simple/modal-screen';
-import CircleIcon from '~/components/simple/circle-icon';
-import { mapState } from 'vuex';
+import ModalScreen from "~/components/simple/modal-screen";
+import CircleIcon from "~/components/simple/circle-icon";
+import TodoTextarea from "~/components/simple/todo-textarea";
+import TodoTime from "~/components/simple/todo-time";
+import AppButton from "~/components/simple/app-button";
+import { mapState } from "vuex";
 
 export default {
   components: {
     ModalScreen,
-    CircleIcon
+    CircleIcon,
+    TodoTime,
+    TodoTextarea,
+    AppButton
   },
   data() {
     return {
-      icons : [
-        { hexCode: '#81B468', svg: 'icoHuman' },
-        { hexCode: '#4f9b4e', svg: 'icoTrain' },
-        { hexCode: '#889BFF', svg: 'icoCar' },
-        { hexCode: '#B588FF', svg: 'icoAirport' },
-        { hexCode: '#73BABE', svg: 'icoShip' },
-        { hexCode: '#90D2E0', svg: 'icoBicycle' },
-        { hexCode: '#F1D691', svg: 'icoEat' },
-        { hexCode: '#F1C591', svg: 'icoBag' },
-        { hexCode: '#FFA488', svg: 'icoCompany' },
-        { hexCode: '#FF8888', svg: 'icoHome' },
-        { hexCode: '#92BFF4', svg: 'icoSun' },
-        { hexCode: '#C587E2', svg: 'icoMoon' },
-      ]
-    }
+      icons: [
+        { hexCode: "#81B468", svgName: "icoHuman" },
+        { hexCode: "#4f9b4e", svgName: "icoTrain" },
+        { hexCode: "#889BFF", svgName: "icoCar" },
+        { hexCode: "#B588FF", svgName: "icoAirport" },
+        { hexCode: "#73BABE", svgName: "icoShip" },
+        { hexCode: "#90D2E0", svgName: "icoBicycle" },
+        { hexCode: "#F1D691", svgName: "icoEat" },
+        { hexCode: "#F1C591", svgName: "icoBag" },
+        { hexCode: "#FFA488", svgName: "icoCompany" },
+        { hexCode: "#FF8888", svgName: "icoHome" },
+        { hexCode: "#92BFF4", svgName: "icoSun" },
+        { hexCode: "#C587E2", svgName: "icoMoon" }
+      ],
+      todo: {
+        icon: {
+          hexCode: '#999',
+          svgName: '',
+        },
+        time: {
+          hour: '00',
+          min: '00',
+        },
+        text: '',
+      },
+      // アイコン選択画面と予定入力画面の切り替えフラグ
+      isSelected: false,
+    };
   },
   computed: {
-    ...mapState('modal-screen', {
-      getModalState: (state) => state.isShow,
-    })
+    ...mapState("modal-screen", {
+      getModalState: state => state.isShow
+    }),
+  },
+  mounted() {
+    console.log('mounted::mix-modal-screen');
+    const { hour, min } = this.getNowTime();
+    this.todo.time.hour = hour;
+    this.todo.time.min = min;
   },
   methods: {
     getNowTime() {
@@ -56,22 +116,61 @@ export default {
       hour = 10 > hour ? `0${hour}` : `${hour}`;
       return { hour, min };
     },
-    clickHandler(hex, path) {
-      const { hour, min } = this.getNowTime();
-      this.$store.commit('todo-item/setData', {
-        hexCode: hex,
-        svgName: path,
+    selectIcon(hex, svg) {
+      this.todo.icon.hexCode = hex;
+      this.todo.icon.svgName = svg;
+      this.isSelected = true;
+    },
+    backToIconSelect() {
+      this.isSelected = false;
+    },
+
+    // todo-textarea からの emit で値を受け取る関数
+    getText(value) {
+      if (value) this.todo.text = value;
+    },
+    // todo-time からの emit で値を受け取る関数
+    getHour(value) {
+      if (value) this.todo.time.hour = value;
+    },
+    // todo-time からの emit で値を受け取る関数
+    getMin(value) {
+      if (value) this.todo.time.min = value;
+    },
+    reset() {
+      this.todo.text = '',
+      this.backToIconSelect();
+    },
+    setDataInTodoItem(todo) {
+      const { icon: {
+        hexCode,
+        svgName,
+      }, time: {
+        hour,
+        min,
+      }, text } = todo;
+      this.$store.commit("todo-item/setData", {
+        hexCode,
+        svgName,
+        text,
         time: {
           h: hour,
-          m: min,
+          m: min
         }
       });
-      this.$store.commit('modal-screen/disableState');
-    }
+      this.reset();
+      this.$store.commit("modal-screen/disableState");
+    },
   }
-}
+};
 </script>
 <style lang="scss" scoped>
+.is-hide {
+  display: none !important;
+}
+.wrap {
+  width: 100%;
+}
 .iconList {
   text-align: center;
   color: #fff;
@@ -83,6 +182,7 @@ export default {
   &__items {
     width: 240px;
     height: 180px;
+    margin: 0 auto;
     list-style: none;
   }
 
@@ -93,9 +193,58 @@ export default {
     &:nth-child(4n) {
       margin-right: 0;
     }
-    &:nth-last-child(-n+4) {
+    &:nth-last-child(-n + 4) {
       margin-bottom: 0;
     }
+  }
+}
+
+.setTodo {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+
+  &__back {
+    position: absolute;
+    margin: 16px 0 0 10%;
+    color: #fff;
+    font-size: 16px;
+    padding-left: 20px;
+
+    &::before {
+      position: absolute;
+      top: 50%;
+      left: 0;
+      width: 16px;
+      height: 16px;
+      border-left: #fff 2px solid;
+      border-bottom: #fff 2px solid;
+      transform: translate(0, -50%) rotate(45deg);
+      content: "";
+    }
+  }
+  &__settingList {
+    position: absolute;
+    width: 80%;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+  &__settingItem {
+    margin-bottom: 24px;
+  }
+  &__text {
+    color: #fff;
+    font-size: 14px;
+    margin-bottom: 4px;
+  }
+  &__planInfo {
+    background-color: #fff;
+    width: 100%;
+    min-height: 56px;
+    font-size: 12px;
+    padding: 4px;
+    border: 1px solid #c4c4c4;
   }
 }
 </style>

--- a/src/components/mix/mix-modal-screen.vue
+++ b/src/components/mix/mix-modal-screen.vue
@@ -48,10 +48,23 @@ export default {
     })
   },
   methods: {
-    clickHandler: function(hex, path) {
+    getNowTime() {
+      const today = new Date();
+      let hour = today.getHours();
+      let min = today.getMinutes();
+      min = 10 > min ? `0${min}` : `${min}`;
+      hour = 10 > hour ? `0${hour}` : `${hour}`;
+      return { hour, min };
+    },
+    clickHandler(hex, path) {
+      const { hour, min } = this.getNowTime();
       this.$store.commit('todo-item/setData', {
         hexCode: hex,
         svgName: path,
+        time: {
+          h: hour,
+          m: min,
+        }
       });
       this.$store.commit('modal-screen/disableState');
     }

--- a/src/components/mix/todo-item.vue
+++ b/src/components/mix/todo-item.vue
@@ -7,25 +7,18 @@
         :size="32"/>
     </div>
     <div class="todoItem__content">
-      <todo-time
-      :hour="hour"
-      :min="min"/>
+      <div class="todoItem__time">{{ hour }}:{{ min }}</div>
     </div>
     <div class="todoItem__content">
-      <todo-textarea
-        :text="text"/>
+      <p class="todoItem__text">{{ text }}</p>
     </div>
   </div>
 </template>
 <script>
-import TodoTime from "~/components/simple/todo-time";
-import TodoTextarea from "~/components/simple/todo-textarea";
 import CircleIcon from "~/components/simple/circle-icon";
 
 export default {
   components: {
-    TodoTime,
-    TodoTextarea,
     CircleIcon
   },
   props: {
@@ -47,6 +40,31 @@ export default {
       width: 100%;
       margin-right: 0;
     }
+  }
+
+  &__text {
+    background-color: #fff;
+    width: 100%;
+    min-height: 56px;
+    font-size: 12px;
+    padding: 4px;
+    border: 1px solid #c4c4c4;
+    &:empty {
+      &::before {
+        content: '予定を入力してください';
+        color: #999;
+      }
+    }
+  }
+
+  &__time {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 56px;
+    height: 24px;
+    background-color: #fff;
+    border: 1px solid #c4c4c4;
   }
 }
 </style>

--- a/src/components/simple/app-button.vue
+++ b/src/components/simple/app-button.vue
@@ -19,11 +19,11 @@ export default {
     font-size: 12px;
     font-weight: bold;
     border-radius: 8px;
-    box-shadow: #ddd 0 3px 6px 0px;
+    box-shadow: rgba(0, 0, 0, .4) 0 3px 6px 0px;
 
     &.isActive {
       background-color: $app-color;
-      box-shadow: #bbb 0 3px 6px 0px;
+      box-shadow: rgba(0, 0, 0, .4) 0 3px 6px 0px;
     }
   }
 </style>

--- a/src/components/simple/modal-screen.vue
+++ b/src/components/simple/modal-screen.vue
@@ -24,7 +24,7 @@ export default {
   align-items: center;
   width: 100vw;
   height: 100vh;
-  background-color: rgba(0, 0, 0, .7);
+  background-color: rgba(0, 0, 0, .8);
   opacity: 1;
   z-index: 100;
   transition: .3s,

--- a/src/components/simple/todo-textarea.vue
+++ b/src/components/simple/todo-textarea.vue
@@ -2,13 +2,15 @@
   <textarea
     class="todoTextarea"
     placeholder="予定を入力してください"
-    :value="text">
+    @change="emit">
   </textarea>
 </template>
 <script>
 export default {
-  props: {
-    text: String,
+  methods: {
+    emit(e) {
+      this.$emit('emitValue', e.target.value);
+    }
   }
 }
 </script>

--- a/src/components/simple/todo-time.vue
+++ b/src/components/simple/todo-time.vue
@@ -99,6 +99,7 @@ export default {
     min: String,
   },
   mounted() {
+    console.log('mounted::todo-time');
     const form = this.$el.children[0];
     if(this.hour) {
       for (const child of form['selectedate-h'].children) {
@@ -122,9 +123,11 @@ export default {
   methods: {
     updateHour(e) {
       console.log(e.target.value);
+      this.$emit('emitHour', e.target.value);
     },
     updateMin(e) {
       console.log(e.target.value);
+      this.$emit('emitMin', e.target.value);
     }
   }
 };

--- a/src/components/simple/todo-time.vue
+++ b/src/components/simple/todo-time.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="todoTime">
     <form class="todoTime__form">
-      <select class="todoTime__hour" name="selectedate-h" id="selectedate-h">
+      <select class="todoTime__hour" name="selectedate-h" @change="updateHour">
         <option value="00">00</option>
         <option value="01">01</option>
         <option value="02">02</option>
@@ -27,7 +27,7 @@
         <option value="22">22</option>
         <option value="23">23</option>
       </select>
-      <select class="todoTime__min" name="selectedate-m" id="selectedate-m">
+      <select class="todoTime__min" name="selectedate-m" @change="updateMin">
         <option value="00">00</option>
         <option value="01">01</option>
         <option value="02">02</option>
@@ -98,10 +98,10 @@ export default {
     hour: String,
     min: String,
   },
-  mounted() { 
+  mounted() {
+    const form = this.$el.children[0];
     if(this.hour) {
-      const h = document.getElementById('selectedate-h');
-      for (const child of h.children) {
+      for (const child of form['selectedate-h'].children) {
         if(child.value === this.hour) {
           child.selected = true;
         } else {
@@ -110,14 +110,21 @@ export default {
       }
     }
     if (this.min) {
-      const m = document.getElementById('selectedate-m');
-      for (const child of m.children) {
+      for (const child of form['selectedate-m'].children) {
         if(child.value === this.min) {
           child.selected = true;
         } else {
           child.selected = false;
         }
       }
+    }
+  },
+  methods: {
+    updateHour(e) {
+      console.log(e.target.value);
+    },
+    updateMin(e) {
+      console.log(e.target.value);
     }
   }
 };


### PR DESCRIPTION
## 概要
元々 todo-item のコンポーネント内でテキスト入力などを行う操作の予定だったが、「詳細入力画面」を作成した方が cloud firestore へデータを登録する際に都合が良いため。
## 作成画面のイメージ
<img src="https://user-images.githubusercontent.com/37236474/56469256-2d442200-6472-11e9-8dcb-b6d4fd31eeb7.png" width="280">