### PR TITLE
追加済の予定を変更する機能を追加した。

### DIFF
--- a/src/components/mix/mix-action-button.vue
+++ b/src/components/mix/mix-action-button.vue
@@ -46,6 +46,7 @@ export default {
     },
     showModal: function() {
       this.toggleState();
+      this.$store.commit('mix-modal-screen/init');
       this.$store.commit('modal-screen/enableState');
     },
     prepareDelete: function() {

--- a/src/components/mix/todo-list.vue
+++ b/src/components/mix/todo-list.vue
@@ -16,7 +16,8 @@
           :iconImg="datum.svgName"
           :text="datum.text"
           :hour="datum.time.h"
-          :min="datum.time.m"/>
+          :min="datum.time.m"
+          @click.native="showModal(datum)"/>
       </li>
     </ul>
   </div>
@@ -49,7 +50,21 @@ export default {
           id: e.target.dataset.id
         });
       }
-    }
+    },
+    showModal: function(datum) {
+      console.log(datum);
+      this.$store.commit('mix-modal-screen/update', {
+        svgName: datum.svgName,
+        hexCode: datum.hexCode,
+        time: {
+          min: datum.time.m,
+          hour: datum.time.h,
+        },
+        text: datum.text,
+        id: datum.id,
+      });
+      this.$store.commit('modal-screen/enableState');
+    },
   }
 };
 </script>

--- a/src/components/simple/todo-textarea.vue
+++ b/src/components/simple/todo-textarea.vue
@@ -2,11 +2,17 @@
   <textarea
     class="todoTextarea"
     placeholder="予定を入力してください"
-    @change="emit">
-  </textarea>
+    @change="emit"
+    ref="textarea"></textarea>
 </template>
 <script>
 export default {
+  props: {
+    text: String,
+  },
+  mounted() {
+    this.$refs.textarea.value = this.text;
+  },
   methods: {
     emit(e) {
       this.$emit('emitValue', e.target.value);
@@ -19,7 +25,7 @@ export default {
   background-color: #fff;
   width: 100%;
   min-height: 56px;
-  font-size: 12px;
+  font-size: 16px;
   padding: 4px;
   border: 1px solid #c4c4c4;
 }

--- a/src/components/simple/todo-time.vue
+++ b/src/components/simple/todo-time.vue
@@ -98,29 +98,38 @@ export default {
     hour: String,
     min: String,
   },
-  mounted() {
-    console.log('mounted::todo-time');
-    const form = this.$el.children[0];
-    if(this.hour) {
-      for (const child of form['selectedate-h'].children) {
-        if(child.value === this.hour) {
-          child.selected = true;
-        } else {
-          child.selected = false;
-        }
-      }
-    }
-    if (this.min) {
-      for (const child of form['selectedate-m'].children) {
-        if(child.value === this.min) {
-          child.selected = true;
-        } else {
-          child.selected = false;
-        }
-      }
+  watch: {
+    min: function (val, oldVal) {
+      console.log(val);
+      this.setTime();
     }
   },
+  mounted() {
+    console.log('mounted::todo-time');
+    this.setTime();
+  },
   methods: {
+    setTime() {
+      const form = this.$el.children[0];
+      if(this.hour) {
+        for (const child of form['selectedate-h'].children) {
+          if(child.value === this.hour) {
+            child.selected = true;
+          } else {
+            child.selected = false;
+          }
+        }
+      }
+      if (this.min) {
+        for (const child of form['selectedate-m'].children) {
+          if(child.value === this.min) {
+            child.selected = true;
+          } else {
+            child.selected = false;
+          }
+        }
+      }
+    },
     updateHour(e) {
       console.log(e.target.value);
       this.$emit('emitHour', e.target.value);

--- a/src/plugins/firebase-query.js
+++ b/src/plugins/firebase-query.js
@@ -21,9 +21,10 @@ export default class {
     const res = await docRef.get().catch((err) => console.log(err));
     return res.data();
   }
-  async updateStoreData(collectionName, docName) {
-    const target = firebase.firestore().collection(collectionName).doc(docName);
-    await target.update({ test: true }).catch((err) => console.log(err))
+  async updateStoreData(collection ,docName, subCollection, subDocName, field) {
+    const docRef = await firebase.firestore().collection(collection).doc(docName)
+      .collection(subCollection).doc(subDocName);
+    await docRef.update(field).catch((err) => console.log(err));
     await console.log('update success');
   }
   async setStoreData(collection ,docName, subCollection, subDocName, data) {

--- a/src/store/mix-modal-screen.js
+++ b/src/store/mix-modal-screen.js
@@ -1,0 +1,65 @@
+
+export const state = () => ({
+  isUpdate: false,
+  isSelected: false,
+  todo: {
+    svgName: '',
+    hexCode: '',
+    time: {
+      hour: '00',
+      min: '00',
+    },
+    text: '',
+    id: '',
+  }
+});
+
+export const mutations = {
+  init(state) {
+    state.isUpdate = false;
+    state.isSelected = false;
+  },
+  update(state, payload) {
+    console.log('UPDATE.STORE');
+    state.isUpdate = true;
+    state.isSelected = true;
+    state.todo.svgName = payload.svgName;
+    state.todo.hexCode = payload.hexCode;
+    state.todo.time.hour = payload.time.hour;
+    state.todo.time.min = payload.time.min;
+    state.todo.text = payload.text;
+    state.todo.id = payload.id;
+  },
+  reset(state) {
+    state.isUpdate = false;
+    state.isSelected = false;
+    state.todo.svgName = '';
+    state.todo.hexCode = '';
+    state.todo.time.hour = '00';
+    state.todo.time.min = '00';
+    state.todo.text = '';
+  },
+  backToIconSelect(state) {
+    console.log('back to icon select');
+    state.isSelected = false;
+  },
+  goToIconInfo(state) {
+    console.log('Go to icon info');
+    state.isSelected = true;
+  },
+  setTodoText(state, text) {
+    state.todo.text = text;
+  },
+  setTodoHour(state, hour) {
+    state.todo.time.hour = hour;
+  },
+  setTodoMin(state, min) {
+    state.todo.time.min = min;
+  },
+  setTodoSvgName(state, name) {
+    state.todo.svgName = name;
+  },
+  setTodoHexCode(state, code) {
+    state.todo.hexCode = code;
+  }
+};

--- a/src/store/todo-item.js
+++ b/src/store/todo-item.js
@@ -34,6 +34,23 @@ export const mutations = {
     fb.setStoreData('todoItem', 'devUser1', 'data', 'plan1', fbData);
     state.data.push(data);
   },
+  updateData(state, payload) {
+    const itemLen = state.data.length;
+    const items = state.data;
+    for (let i = 0; i < itemLen; i++) {
+      if (items[i].id == payload.id) {
+        console.log(items[i]);
+        items[i].text = payload.text;
+        items[i].time = payload.time;
+        items[i].hexCode = payload.hexCode;
+        items[i].svgName = payload.svgName;
+        const field = {};
+        const key = `item${payload.id}`;
+        field[key] = payload;
+        fb.updateStoreData('todoItem', 'devUser1', 'data', 'plan1', field);
+      }
+    }
+  },
   isDeletable(state) {
     state.isDeletable = !state.isDeletable;
   },


### PR DESCRIPTION
## 変更点
* mix-modal-screen の状態管理を vuex store へ移行
* todo-item をクリックで予定の編集を可能にした（予定の追加時に開くモーダル画面を todo-item クリック時も開くように変更）
* 予定編集画面（モーダル画面）で予定を入力する際の font-size を 12 から 16 へ変更し、入力画面がズームされる仕様を修正
* todo-item の予定内容を変更時 firestore でも内容が更新されるようにした